### PR TITLE
plk: require net/http

### DIFF
--- a/lib/ae_network_connection_exception.rb
+++ b/lib/ae_network_connection_exception.rb
@@ -1,4 +1,5 @@
 require "ae_network_connection_exception/version"
+require "net/http"
 require "socket"
 
 module AeNetworkConnectionException


### PR DESCRIPTION
Previously this was not needed because older versions of bundler
required net/http. Now that bundler autoloads its dependencies, this
'require' is needed.