### PR TITLE
add HTTP::ConnectTimeoutError to list of errors if http gem is used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org' # global source
 source 'https://rubygems.org' do
   gem 'appraisal', '>= 2.3', '< 3'
   gem 'bundler', '>= 2.2', '< 3'
+  gem 'http', '~> 5.1'
   gem 'minitest', '>= 5.15', '< 6'
   gem 'minitest-reporters', '>= 1.4', '< 2'
   gem 'mocha', '>= 1.13', '< 2'

--- a/lib/ae_network_connection_exception.rb
+++ b/lib/ae_network_connection_exception.rb
@@ -44,7 +44,11 @@ module AeNetworkConnectionException
     private
 
     def other_exceptions
-      defined?(RestClient::Exceptions::OpenTimeout) ? [RestClient::Exceptions::OpenTimeout] : []
+      res = []
+      res << RestClient::Exceptions::OpenTimeout if defined?(RestClient::Exceptions::OpenTimeout)
+      res << HTTP::ConnectTimeoutError if defined?(HTTP::ConnectTimeoutError)
+
+      res
     end
 
     def raise_if_exception_message_matches(exception, pattern)

--- a/test/ae_network_connection_exception_test.rb
+++ b/test/ae_network_connection_exception_test.rb
@@ -55,6 +55,11 @@ module AeNetworkConnectionException
       assert_connection_not_established_thrown_for(open_timeout)
     end
 
+    def test_ae_network_connection_exception_try__raises_connection_not_establised_exception_http_connect_time_out
+      open_timeout = HTTP::ConnectTimeoutError.new
+      assert_connection_not_established_thrown_for(open_timeout)
+    end
+
     def test_exception_signatures
       assert_equal expected_signatures.size, AeNetworkConnectionException.exception_signatures.size
 
@@ -67,9 +72,18 @@ module AeNetworkConnectionException
       old = RestClient::Exceptions::OpenTimeout
       RestClient::Exceptions.send(:remove_const, :OpenTimeout)
 
-      assert_empty AeNetworkConnectionException.send(:other_exceptions)
+      refute AeNetworkConnectionException.send(:other_exceptions).include?(old)
     ensure
       RestClient::Exceptions.const_set(:OpenTimeout, old)
+    end
+
+    def test_http_connect_time_out_not_defined
+      old = HTTP::ConnectTimeoutError
+      HTTP.send(:remove_const, :ConnectTimeoutError)
+
+      refute AeNetworkConnectionException.send(:other_exceptions).include?(old)
+    ensure
+      HTTP.const_set(:ConnectTimeoutError, old)
     end
 
     private

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,5 +22,6 @@ require 'ae_network_connection_exception'
 require 'minitest/autorun'
 require 'minitest/reporters'
 require 'rest-client'
+require 'http'
 
 MiniTest::Reporters.use! unless ENV['RM_INFO']


### PR DESCRIPTION
When the `http` gem is used, a `HTTP::ConnectTimeoutError` error, instead of the `Net::OpenTimeout` error, will be thrown when the application timed out trying to connect to the destination.  

This PR add `HTTP::ConnectTimeoutError` to the list of errors that triggers the `ConnectionNotEstablished` error