### PR TITLE
Add Backstage catalog metadata file(s)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: ae_network_connection_exception
+  description: This catalog entity description has been auto-generated
+  tags:
+    - oss
+  annotations:
+    appfolio.com/package-location: url:https://rubygems.org/gems/ae_network_connection_exception
+    appfolio.com/package-type: gem
+  name: ae-network-connection-exception
+spec:
+  type: library
+  lifecycle: unknown
+  owner: engineering


### PR DESCRIPTION
All Backstage component, resource, and api catalog metadata files are migrating to project repositories to lower the rate of effort for catalog maintenance.

[_Created by Sourcegraph batch change `modethirteen/migrate-developer-portal-catalog-open-source-metadata`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/migrate-developer-portal-catalog-open-source-metadata)