### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   gem-tool: appfolio/gem-tool@volatile
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:
@@ -9,6 +10,8 @@ workflows:
       - gem-tool/rake_test:
           name: test_ruby-<< matrix.ruby_version >>
           executor_tag: ruby
+          after-checkout-steps:
+            - public-packages/setup
           matrix:
             parameters:
               ruby_version:

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_network_connection_exception-gem/'
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-ae_network_connection_exception-gem/' do
   gem 'appraisal', '>= 2.5', '< 3'
-  gem 'bundler', '>= 2.6', '< 3'
+  gem 'bundler', '>= 2.6', '< 5'
   gem 'debug', '>= 1.11', '< 2'
   gem 'http', '>= 5.3', '< 6'
   gem 'minitest', '>= 6', '< 7'


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile (both global and block form)
- Added `public-packages` orb and setup step to CircleCI config
- Updated `allowed_push_host` in gemspec to JFrog URL
- Updated `package-location` annotation in catalog-info.yaml
- Created `.github/dependabot.yaml` with JFrog registry configuration

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration